### PR TITLE
build: update CircleCI images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ commands:
 jobs:
   python38-quality:
     docker:
-      - image: circleci/python:3.8
+      - image: cimg/python:3.8
     steps:
       - checkout
       - restore_cache:
@@ -32,7 +32,7 @@ jobs:
 
   python38:
     docker:
-      - image: circleci/python:3.8
+      - image: cimg/python:3.8
     steps:
       - checkout
       - restore_cache:
@@ -50,7 +50,7 @@ jobs:
 
   pii_check:
     docker:
-      - image: circleci/python:3.8
+      - image: cimg/python:3.8
     steps:
       - checkout
       - restore_cache:


### PR DESCRIPTION
### Description
This replaces old CircleCI images with new ones

### Supporting Information
CircleCI [post](https://support.circleci.com/hc/en-us/articles/4417542273179-GitHub-SSH-Deprecation-Information-Resolutions?mkt_tok=NDg1LVpNSC02MjYAAAGCo4YSSuB6UK-NysyHLRzoQjSgXUorpHVqigol0steNsyhWGM2NntuVxZ92Gfpv1za6PrWr4JednW46hOItOA2PcrYmQG5O4t4quw5VvE1mEJs#Jobs-using-circleci-convenience-images-(i.e.-circleci/ruby:2.2.6))